### PR TITLE
temporal database support

### DIFF
--- a/include/io.h
+++ b/include/io.h
@@ -60,7 +60,7 @@ public:
     // write grid data to output file
     void write_grid(Grid&);
     // general function for write out data in hdf5
-    void write_data_h5(Grid&, std::string&, std::string&, CUSTOMREAL*, int, bool);
+    void write_data_h5(Grid&, std::string&, std::string&, CUSTOMREAL*, int, bool, bool for_tmp_db=false);
     // general function for write out data in hdf5 with merging subdomains
     void write_data_merged_h5(Grid&, std::string&, std::string&, std::string&, CUSTOMREAL*, bool, bool no_group=true);
     // general function for write out data in ascii
@@ -81,6 +81,8 @@ public:
     //void write_tmp_tau(Grid&, int);
     // write result timetable T
     void write_T(Grid&, int);
+    // write temporal timetable T in a separated file
+    void write_T_tmp(Grid&);
     // write residual (resudual = true_solution - result)
     void write_residual(Grid&);
     // write adjoint field
@@ -138,15 +140,27 @@ public:
 
     // read model data
     void read_model(std::string&, const char*, CUSTOMREAL*, int, int, int);
-    // read Travel time from file for earthquake relocation
+    // read Travel time from file for earthquake relocation and common receiver double-difference
     void read_T(Grid&);
+    // read Travel time from a temporal file for earthquake relocation and common receiver double-difference
+    void read_T_tmp(Grid&);
 
     void read_data_ascii(Grid&, std::string&);
+
+    //
+    // delete functions
+    //
+    // Any deletion of data should be done on a created hdf5. Because the design of hdf5 is that
+    // it is not possible to delete data from an existing hdf5 file. The only way to do so is to
+    // create a new hdf5 file and copy the necessary data from the old one to the new one.
+    // Therefore, the deletion of data is not implemented in this class.
+    // Reference : https://stackoverflow.com/questions/1124994/removing-data-from-a-hdf5-file
 
 private:
     // member variables
     std::string h5_output_grid_fname = "out_data_grid.h5"; // output file name
     std::string h5_output_fname      = "out_data.h5";      // output file name
+    std::string h5_output_fname_tmp  = "out_data_tmp.h5";  // output file name
     std::string xdmf_output_fname    = "out_data.xmf";     // output file name
     std::string h5_group_name_grid   = "Mesh";               // group name for grid data
     std::string h5_group_name_event  = "Event";              // group name for event data

--- a/include/main_routines_earthquake_relocation.h
+++ b/include/main_routines_earthquake_relocation.h
@@ -84,7 +84,7 @@ void calculate_traveltime_for_all_src_rec(InputParams& IP, Grid& grid, IO_utils&
         It->run_iteration_forward(IP, grid, io, first_init);
 
         // writeout traveltime field
-        io.write_T(grid, 0);
+        io.write_T_tmp(grid);
 
         if (proc_store_srcrec)
             IP.src_map[name_sim_src].is_T_written_into_file = true;
@@ -115,7 +115,7 @@ std::vector<CUSTOMREAL> calculate_gradient_objective_function(InputParams& IP, G
         io.change_group_name_for_source();
 
         // load travel time field on grid.T_loc
-        io.read_T(grid);
+        io.read_T_tmp(grid);
 
         // calculate travel time at the actual source location
         recs.interpolate_and_store_arrival_times_at_rec_position(IP, grid, name_sim_src);

--- a/include/main_routines_inversion_mode.h
+++ b/include/main_routines_inversion_mode.h
@@ -58,7 +58,7 @@ inline void pre_run_forward_only(InputParams& IP, Grid& grid, IO_utils& io, int 
                         << std::endl;
             }
 
-            io.read_T(grid);
+            io.read_T_tmp(grid);
         } else {
             // We need to solve eikonal equation
             if (myrank == 0){
@@ -72,7 +72,7 @@ inline void pre_run_forward_only(InputParams& IP, Grid& grid, IO_utils& io, int 
             It->run_iteration_forward(IP, grid, io, first_init);
 
             // writeout travel time field
-            io.write_T(grid, 0);
+            io.write_T_tmp(grid);
 
             if (proc_store_srcrec) // only proc_store_srcrec has the src_map object
                 IP.src_map[name_sim_src].is_T_written_into_file = true;
@@ -180,7 +180,7 @@ inline std::vector<CUSTOMREAL> run_simulation_one_step(InputParams& IP, Grid& gr
                             << std::endl;
                 }
                 // load travel time field on grid.T_loc
-                io.read_T(grid);
+                io.read_T_tmp(grid);
             } else {
                 // We need to compute traveltime field, including such cases:
                 //  case 1. is_read_time == false;

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -29,10 +29,12 @@ IO_utils::IO_utils(InputParams& IP) {
                 // for simultaneous run, data file is created for each simulation group
                 h5_output_fname = "./out_data_sim_group_" + std::to_string(id_sim) + ".h5";
                 xdmf_output_fname = "./out_data_sim_group_"+std::to_string(id_sim)+".xmf";
+                h5_output_fname_tmp = "./tmp_db_sim_group_" + std::to_string(id_sim) + ".h5";
             } else {
                 // otherwise, only one single data file is created for storing model params
                 h5_output_fname = "./out_data_sim.h5";
                 xdmf_output_fname = "./out_data_sim.xmf";
+                h5_output_fname_tmp = "./tmp_db_sim.h5";
             }
             // create data file
             h5_create_file_by_group_main(h5_output_fname);
@@ -384,14 +386,14 @@ void IO_utils::finalize_xdmf_file(){
 
 #ifdef USE_HDF5
 // function to write data to HDF5 file without merging subdomains
-void IO_utils::write_data_h5(Grid& grid, std::string& str_group, std::string& str_dset, CUSTOMREAL* array, int i_inv, bool model_data) {
-    std::string str_dset_h5   = str_dset + "_inv_" + int2string_zero_fill(i_inv);
-    std::string str_dset_xdmf;
-    if (!model_data)
-        // str_dset_xdmf = str_dset + "_src_" + int2string_zero_fill(id_sim_src); // use different name for xdmf
-        str_dset_xdmf = str_dset + "_src_" + name_sim_src; // use different name for xdmf
+void IO_utils::write_data_h5(Grid& grid, std::string& str_group, std::string& str_dset,
+                             CUSTOMREAL* array, int i_inv, bool model_data, bool for_tmp_db) {
+
+    std::string str_dset_h5 = "dummy";
+    if (!for_tmp_db)
+        str_dset_h5 = str_dset + "_inv_" + int2string_zero_fill(i_inv);
     else
-        str_dset_xdmf = str_dset; // use different name for xdmf
+        str_dset_h5 = str_dset;
 
     // write true solution to h5 file
     if (myrank == 0 && if_verbose)
@@ -428,13 +430,21 @@ void IO_utils::write_data_h5(Grid& grid, std::string& str_group, std::string& st
     // close file
     h5_close_file_collective();
 
-    // add xdmf file in
-    insert_data_xdmf(str_group, str_dset_xdmf, str_dset_h5);
+    if (!for_tmp_db) {
+        std::string str_dset_xdmf;
+        if (!model_data)
+            str_dset_xdmf = str_dset + "_src_" + name_sim_src; // use different name for xdmf
+        else
+            str_dset_xdmf = str_dset; // use different name for xdmf
 
+        // add xdmf file in
+        insert_data_xdmf(str_group, str_dset_xdmf, str_dset_h5);
+    }
 }
 
 // function to write data to HDF5 file with merging subdomains
-void IO_utils::write_data_merged_h5(Grid& grid,std::string& str_filename, std::string& str_group, std::string& str_dset, CUSTOMREAL* array, bool inverse_field, bool no_group) {
+void IO_utils::write_data_merged_h5(Grid& grid,std::string& str_filename, std::string& str_group, std::string& str_dset,
+                                    CUSTOMREAL* array, bool inverse_field, bool no_group) {
 
     // write true solution to h5 file
     if (myrank == 0 && if_verbose)
@@ -919,6 +929,39 @@ void IO_utils::write_T(Grid& grid, int i_inv) {
 #endif
     } else if(output_format==OUTPUT_FORMAT_ASCII){
         std::string dset_name = "T_res_inv_" + int2string_zero_fill(i_inv);
+        std::string fname = create_fname_ascii(dset_name);
+        write_data_ascii(grid, fname, grid.get_T());
+    }
+}
+
+
+void IO_utils::write_T_tmp(Grid& grid) {
+    if (!subdom_main) return;
+
+    if (output_format==OUTPUT_FORMAT_HDF5){
+#ifdef USE_HDF5
+        // temporally replice a filename for T_tmp
+        std::string h5_fname_back = h5_output_fname;
+        h5_output_fname = h5_output_fname_tmp;
+
+        // create file if not exist
+        std::string out_file_full = output_dir+"/"+h5_output_fname;
+        if (!is_file_exist(out_file_full.c_str()))
+            h5_create_file_by_group_main(h5_output_fname);
+
+        // dataset name
+        std::string h5_dset_name = "T_tmp";
+        bool for_tmp_db = true;
+        write_data_h5(grid, h5_group_name_data, h5_dset_name, grid.get_T(), 0, src_data, for_tmp_db);
+
+        // restore filename
+        h5_output_fname = h5_fname_back;
+#else
+        std::cout << "ERROR: HDF5 is not enabled" << std::endl;
+        exit(1);
+#endif
+    } else if(output_format==OUTPUT_FORMAT_ASCII){
+        std::string dset_name = "T_tmp";
         std::string fname = create_fname_ascii(dset_name);
         write_data_ascii(grid, fname, grid.get_T());
     }
@@ -1510,6 +1553,44 @@ void IO_utils::read_T(Grid& grid) {
     // set to T_loc array from grid.vis_data
     grid.set_array_from_vis(grid.T_loc);
 }
+
+
+void IO_utils::read_T_tmp(Grid& grid) {
+    if (!subdom_main) return;
+
+    if (output_format == OUTPUT_FORMAT_HDF5) {
+        // read traveltime field from HDF5 file
+#ifdef USE_HDF5
+        // temporally replice a filename for T_tmp
+        std::string h5_fname_back = h5_output_fname;
+        h5_output_fname = h5_output_fname_tmp;
+
+        // h5_group_name_data = "src_" + std::to_string(id_sim_src);
+        h5_group_name_data = "src_" + name_sim_src;
+        std::string h5_dset_name = "T_tmp";
+
+        read_data_h5(grid, grid.vis_data, h5_group_name_data, h5_dset_name);
+
+        // recover h5_output_fname
+        h5_output_fname = h5_fname_back;
+#else
+        std::cerr << "Error: HDF5 is not enabled." << std::endl;
+        exit(1);
+#endif
+    } else if (output_format == OUTPUT_FORMAT_ASCII) {
+        // read traveltime field from ASCII file
+        std::string dset_name = "T_tmp";
+        std::string filename = create_fname_ascii(dset_name);
+
+        read_data_ascii(grid, filename);
+    }
+
+    // set to T_loc array from grid.vis_data
+    grid.set_array_from_vis(grid.T_loc);
+}
+
+
+
 
 
 void IO_utils::read_data_ascii(Grid& grid, std::string& fname){


### PR DESCRIPTION
This update adds a function in io.h/cpp which create the additional hdf5 files for separately store the temporal T fields.
Before, the same hdf5 output file was used for both storing a temporal T and result data, which leaded unnecessary saved data and unnecessary large files (even if a user only want to output the model data, T data for all source were output in the former code).

This update will create additional hdf5 files with "tmp_db_..." file name. Users can just remove them after finishing a calculation.

The common receiver double-difference and source relocation routine use this temporal database.